### PR TITLE
allow custom options for AutoComplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ This will not update the map at all. This input is strictly for returning a loca
 
 All the props are listed below. You can also use pure css to style if you wish by targeting the class `storeLocatorAutocomplete`.
 
+`customOptions` can be used to set custom options, check [google Autocomplete doc](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete) for available options.
+
 Note: This is a seperate component from the map so you should pass your api key in here as well if you wish to use this.
 
 ```jsx
@@ -275,6 +277,7 @@ render(){
         getValue={this.myFunc.bind(this)}
         googleApiKey={'googleapikey'}
         placeholder="My placeholder string"
+        customOptions={{componentRestrictions: {country: 'fr'}}}
       />
     </div>
   )

--- a/src/containers/AutoComplete.js
+++ b/src/containers/AutoComplete.js
@@ -13,10 +13,11 @@ class AutoComplete extends Component {
 
  componentDidMount() {
   if (this.props.loaded) {
-   const { google } = this.props
+   const { google, customOptions } = this.props
    // Try using differnet types options. Or just look at search comp and copy directly
    const options = {
-    types: [`address`]
+    types: [`address`],
+    ...customOptions
    }
    this.autocomplete = new google.maps.places.Autocomplete(this.input, options)
    this.autocomplete.addListener('place_changed', this.updateInput)


### PR DESCRIPTION
allows custom options for the google autocomplete through `customOptions` prop (check [README.md](https://github.com/monkeydri/react-store-locator/tree/autocomplete-custom-options#autocomplete-input) for instructions)

fix issue #11 

