### PR TITLE
allow custom options for Map and Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,8 @@ This will not update the map at all. This input is strictly for returning a loca
 
 All the props are listed below. You can also use pure css to style if you wish by targeting the class `storeLocatorAutocomplete`.
 
+`customOptions` can be used to set custom options, check [google Autocomplete doc](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete) for available options.
+
 Note: This is a seperate component from the map so you should pass your api key in here as well if you wish to use this.
 
 ```jsx
@@ -321,6 +323,35 @@ render(){
   )
 }
 ```
+
+### Control results returned on search
+
+`customOptions` prop can be used on `Map`, `Search` and `AutoComplete` component to customize the results returned by Google in the search fields, check [google Autocomplete doc](https://developers.google.com/maps/documentation/javascript/places-autocomplete#add_autocomplete) for available options.
+
+Example with `AutoComplete` to display only results from France :
+
+```jsx
+import { AutoComplete } from 'react-store-locator';
+
+myFunc(value){
+  console.log(value) // place object returned
+}
+
+render(){
+  return(
+    <div>
+      <AutoComplete
+        style={{color: 'red'}}
+        getValue={this.myFunc.bind(this)}
+        googleApiKey={'googleapikey'}
+        placeholder="My placeholder string"
+        customOptions={{componentRestrictions: {country: 'fr'}}}
+      />
+    </div>
+  )
+}
+```
+
 
 ### Center Marker on Move
 

--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -20,7 +20,7 @@ export default class Map extends Component {
 		this.changeMap = this.changeMap.bind(this)
 		this.toggleLocation = this.toggleLocation.bind(this)
 		this.closeLocation = this.closeLocation.bind(this)
-		this.onPlacesChanged = this.onPlacesChanged.bind(this)
+		this.onPlaceChanged = this.onPlaceChanged.bind(this)
 		this.handleMapLoad = this.handleMapLoad.bind(this)
 		this.onClusterClick = this.onClusterClick.bind(this)
 
@@ -28,7 +28,7 @@ export default class Map extends Component {
 			updatedLocations: this.props.locations,
 			center: { lat: 0, lng: 0 },
 			zoom: 6,
-			places: null,
+			place: null,
 			mapLoaded: false,
 			props: null,
 			prevBounds: null
@@ -146,14 +146,14 @@ export default class Map extends Component {
 		}
 	}
 
-	onPlacesChanged() {
-		let places = this.searchBox.getPlaces()
-		if (places === this.state.places) places = undefined
-		if (places) {
+	onPlaceChanged() {
+		let place = this.searchBox.getPlace()
+		if (place === this.state.place) place = undefined
+		if (place) {
 			if (this.props.submitSearch) {
 				this.props.submitSearch()
 			}
-			this.setState({ places })
+			this.setState({ place })
 			if (places.length > 0) {
 				const firstLocation = places[0]
 				const { geometry } = firstLocation
@@ -185,13 +185,13 @@ export default class Map extends Component {
 	}
 
 	componentDidMount() {
-		const { google } = this.props
+		const { google, options } = this.props
 		if (this.props.initSearch) {
 			this.searchInput.value = this.props.initSearch
 		}
 		if (this.searchInput) {
-			this.searchBox = new google.maps.places.SearchBox(this.searchInput)
-			this.searchBox.addListener('places_changed', this.onPlacesChanged)
+			this.searchBox = new google.maps.places.Autocomplete(this.searchInput, options)
+			this.searchBox.addListener('place_changed', this.onPlaceChanged)
 		}
 		let defaultZoom = 8,
 			defaultCenter = { lat: 0, lng: 180 }
@@ -405,7 +405,7 @@ export default class Map extends Component {
 					<input
 						className="storeLocatorInput"
 						style={searchStyle.searchInput}
-						onChange={this.onPlacesChanged}
+						onChange={this.onPlaceChanged}
 						ref={input => (this.searchInput = input)}
 						type="text"
 						placeholder="Enter Your Location..."

--- a/src/containers/Search.js
+++ b/src/containers/Search.js
@@ -2,14 +2,15 @@ import React, { Component } from 'react';
 import { fitBounds } from 'google-map-react/utils';
 import { mapState } from '../state';
 
-function initSearch(google) {
+function initSearch(google, options) {
   const input = document.querySelector('.storeLocatorSearchInput');
   if (input) {
-    const searchBox = new google.maps.places.SearchBox(input);
+    const searchBox = new google.maps.places.Autocomplete(input);
 
-    searchBox.addListener('places_changed', function() {
-      const places = searchBox.getPlaces();
-      places.forEach(place => {
+    searchBox.addListener('place_changed', function() {
+      const place = searchBox.getPlace();
+      if (place)
+      {
         if (!place.geometry) {
           console.warn('Returned place contains no geometry');
           return;
@@ -27,7 +28,7 @@ function initSearch(google) {
           }
         };
         mapState.setState({ newBounds });
-      });
+      };
     });
   }
 }


### PR DESCRIPTION
This uses [Google Autocomplete](https://developers.google.com/maps/documentation/javascript/places-autocomplete) for Map and Search search inputs so `customOptions` can be passed to those components the same way it can be for Autocomplete component.

It also re-adds `customOptions` example for Autocomplete in doc (README.md) which had been deleted.