### PR TITLE
Control map place prop

### DIFF
--- a/src/containers/AutoComplete.js
+++ b/src/containers/AutoComplete.js
@@ -64,6 +64,8 @@ class AutoComplete extends Component {
    if (place.name) {
     updatedAddress.searchInput = place.name
    }
+   updatedAddress.place = place;
+
    this.props.getValue(updatedAddress)
 
    if (place.formatted_address) {

--- a/src/containers/AutoComplete.js
+++ b/src/containers/AutoComplete.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react'
 import { GoogleApiWrapper } from 'google-maps-react'
 
+import { parsePlace } from '../utils/parse-place'
+
 class AutoComplete extends Component {
  constructor(props) {
   super(props)
@@ -33,38 +35,7 @@ class AutoComplete extends Component {
   let place = this.autocomplete.getPlace()
   if (place === this.state.place) place = undefined
   if (place) {
-   let updatedAddress = {}
-   if (place.address_components) {
-    place.address_components.map(comp => {
-     if (comp.types.includes('postal_code')) {
-      updatedAddress.zip = comp.short_name
-     }
-     if (comp.types.includes('street_number')) {
-      updatedAddress.address = comp.short_name
-     }
-     if (comp.types.includes('route')) {
-      updatedAddress.address
-       ? (updatedAddress.address += ` ${comp.short_name}`)
-       : (updatedAddress.address = comp.short_name)
-     }
-     if (comp.types.includes('locality')) {
-      updatedAddress.city = comp.short_name
-     }
-     if (comp.types.includes('administrative_area_level_1')) {
-      updatedAddress.state = comp.short_name
-     }
-     if (comp.types.includes('country')) {
-      updatedAddress.country = comp.short_name
-     }
-    })
-   }
-   if (place.formatted_address) {
-    updatedAddress.formatted_address = place.formatted_address
-   }
-   if (place.name) {
-    updatedAddress.searchInput = place.name
-   }
-   updatedAddress.place = place;
+   const updatedAddress = parsePlace(place)
 
    this.props.getValue(updatedAddress)
 

--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -146,41 +146,40 @@ export default class Map extends Component {
 		}
 	}
 
+	moveMap(place) {
+		this.setState({ place })
+		const { geometry } = place
+		const newBounds = {
+			ne: {
+				lat: geometry.viewport.getNorthEast().lat(),
+				lng: geometry.viewport.getNorthEast().lng()
+			},
+			sw: {
+				lat: geometry.viewport.getSouthWest().lat(),
+				lng: geometry.viewport.getSouthWest().lng()
+			}
+		}
+		let size = {}
+		if (this.mapEl) {
+			size = {
+				width: this.mapEl.offsetWidth,
+				height: this.mapEl.offsetHeight
+			}
+		}
+		const { center, zoom } = fitBounds(newBounds, size)
+		this.setState({
+			center: center,
+			zoom: zoom.toString().length > 1 ? 9 : zoom
+		})
+	}
+
 	onPlaceChanged() {
 		let place = this.searchBox.getPlace()
-		if (place === this.state.place) place = undefined
-		if (place) {
+		if (place && place !== this.state.place) {
 			if (this.props.submitSearch) {
 				this.props.submitSearch()
 			}
-			this.setState({ place })
-			if (places.length > 0) {
-				const firstLocation = places[0]
-				const { geometry } = firstLocation
-				const newBounds = {
-					ne: {
-						lat: geometry.viewport.getNorthEast().lat(),
-						lng: geometry.viewport.getNorthEast().lng()
-					},
-					sw: {
-						lat: geometry.viewport.getSouthWest().lat(),
-						lng: geometry.viewport.getSouthWest().lng()
-					}
-				}
-				let size = {}
-				if (this.mapEl) {
-					size = {
-						width: this.mapEl.offsetWidth,
-						height: this.mapEl.offsetHeight
-					}
-				}
-
-				const { center, zoom } = fitBounds(newBounds, size)
-				this.setState({
-					center: center,
-					zoom: zoom.toString().length > 1 ? 9 : zoom
-				})
-			}
+			this.moveMap(place)
 		}
 	}
 
@@ -240,6 +239,15 @@ export default class Map extends Component {
 			center: defaultCenter
 		})
 	}
+
+	componentDidUpdate(prevProps, prevState) 
+	{
+		const place = this.props.place;
+
+		if (place && prevProps.place !== place && place !== this.state.place) { 
+			this.moveMap(place); 
+		} 
+	} 
 
 	handleMapLoad({ map }) {
 		this.map = map

--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -11,6 +11,7 @@ import searchStyle from './SearchStyle'
 import { createClusters } from '../utils/clustering'
 import { objectsAreEqual } from '../utils/objects'
 import { strToFixed } from '../utils/string'
+import { parsePlace } from '../utils/parse-place'
 
 export default class Map extends Component {
 	constructor(props) {
@@ -180,6 +181,11 @@ export default class Map extends Component {
 				this.props.submitSearch()
 			}
 			this.moveMap(place)
+
+			const updatedAddress = parsePlace(place)
+			if (this.props.getValue) {
+				this.props.getValue(updatedAddress)
+			}
 		}
 	}
 

--- a/src/containers/Search.js
+++ b/src/containers/Search.js
@@ -2,10 +2,12 @@ import React, { Component } from 'react';
 import { fitBounds } from 'google-map-react/utils';
 import { mapState } from '../state';
 
-function initSearch(google, options) {
+import { parsePlace } from '../utils/parse-place'
+
+function initSearch(google, options, getValue) {
   const input = document.querySelector('.storeLocatorSearchInput');
   if (input) {
-    const searchBox = new google.maps.places.Autocomplete(input);
+    const searchBox = new google.maps.places.Autocomplete(input, options);
 
     searchBox.addListener('place_changed', function() {
       const place = searchBox.getPlace();
@@ -28,6 +30,11 @@ function initSearch(google, options) {
           }
         };
         mapState.setState({ newBounds });
+
+        const updatedAddress = parsePlace(place)
+        if (getValue) {
+          getValue(updatedAddress)
+        }
       };
     });
   }
@@ -35,7 +42,7 @@ function initSearch(google, options) {
 
 export default props => {
   if (props.google) {
-    initSearch(props.google);
+    initSearch(props.google, props.options || {}, props.getValue); 
   }
 
   return (

--- a/src/utils/parse-place.js
+++ b/src/utils/parse-place.js
@@ -1,0 +1,38 @@
+const parsePlace = (place) => {
+	let updatedAddress = {}
+	if (place.address_components) {
+		place.address_components.map(comp => {
+			if (comp.types.includes('postal_code')) {
+				updatedAddress.zip = comp.short_name
+			}
+			if (comp.types.includes('street_number')) {
+				updatedAddress.address = comp.short_name
+			}
+			if (comp.types.includes('route')) {
+				updatedAddress.address
+				? (updatedAddress.address += ` ${comp.short_name}`)
+				: (updatedAddress.address = comp.short_name)
+			}
+			if (comp.types.includes('locality')) {
+				updatedAddress.city = comp.short_name
+			}
+			if (comp.types.includes('administrative_area_level_1')) {
+				updatedAddress.state = comp.short_name
+			}
+			if (comp.types.includes('country')) {
+				updatedAddress.country = comp.short_name
+			}
+		})
+	}
+	if (place.formatted_address) {
+		updatedAddress.formatted_address = place.formatted_address
+	}
+	if (place.name) {
+		updatedAddress.searchInput = place.name
+	}
+	updatedAddress.place = place;
+
+	return updatedAddress;
+}
+
+export { parsePlace }


### PR DESCRIPTION
This allows to control map location via a `place` prop which is a [Google Maps API Place PlaceResult](https://developers.google.com/maps/documentation/javascript/reference/places-service#PlaceResult).

`place` object can be retrieved from Autocomplete component via additional `place` key in object returned by `getValue` callback.

additional `place` key in object returned by `getValue` callback also allows to access underlying attributes otherwise not available such as latitude, longitude and custom handling of search components (ex to get separate address street and number).