### PR TITLE
Select suggestion on return key press

### DIFF
--- a/src/containers/AutoComplete.js
+++ b/src/containers/AutoComplete.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { GoogleApiWrapper } from 'google-maps-react'
 
 import { parsePlace } from '../utils/parse-place'
-import { tagAutoCompleteContainer, enableEnterKey } from '../utils/suggestion-event'
+import { enableEnterKey } from '../utils/suggestion-event'
 
 class AutoComplete extends Component {
  constructor(props) {
@@ -24,8 +24,7 @@ class AutoComplete extends Component {
    }
    this.autocomplete = new google.maps.places.Autocomplete(this.input, options)
    this.autocomplete.addListener('place_changed', this.updateInput)
-   enableEnterKey(this.input);
-   tagAutoCompleteContainer(this.input); 
+   enableEnterKey(this.input, this.autocomplete)
   }
  }
 

--- a/src/containers/AutoComplete.js
+++ b/src/containers/AutoComplete.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { GoogleApiWrapper } from 'google-maps-react'
 
 import { parsePlace } from '../utils/parse-place'
-import { enableEnterKey } from '../utils/suggestion-event'
+import { tagAutoCompleteContainer, enableEnterKey } from '../utils/suggestion-event'
 
 class AutoComplete extends Component {
  constructor(props) {
@@ -25,6 +25,7 @@ class AutoComplete extends Component {
    this.autocomplete = new google.maps.places.Autocomplete(this.input, options)
    this.autocomplete.addListener('place_changed', this.updateInput)
    enableEnterKey(this.input);
+   tagAutoCompleteContainer(this.input); 
   }
  }
 

--- a/src/containers/AutoComplete.js
+++ b/src/containers/AutoComplete.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react'
 import { GoogleApiWrapper } from 'google-maps-react'
 
 import { parsePlace } from '../utils/parse-place'
+import { enableEnterKey } from '../utils/suggestion-event'
 
 class AutoComplete extends Component {
  constructor(props) {
@@ -23,6 +24,7 @@ class AutoComplete extends Component {
    }
    this.autocomplete = new google.maps.places.Autocomplete(this.input, options)
    this.autocomplete.addListener('place_changed', this.updateInput)
+   enableEnterKey(this.input);
   }
  }
 
@@ -55,7 +57,7 @@ class AutoComplete extends Component {
     }
    }
   } else if (!place) {
-   if (this.props.getValue) {
+   if (this.props.getValue && e) {
     this.props.getValue(e.target.value)
    }
   }

--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -12,6 +12,7 @@ import { createClusters } from '../utils/clustering'
 import { objectsAreEqual } from '../utils/objects'
 import { strToFixed } from '../utils/string'
 import { parsePlace } from '../utils/parse-place'
+import { tagAutoCompleteContainer, enableEnterKey } from '../utils/suggestion-event'
 
 export default class Map extends Component {
 	constructor(props) {
@@ -191,12 +192,15 @@ export default class Map extends Component {
 
 	componentDidMount() {
 		const { google, options } = this.props
+		const input = this.searchInput
 		if (this.props.initSearch) {
-			this.searchInput.value = this.props.initSearch
+			input.value = this.props.initSearch
 		}
 		if (this.searchInput) {
-			this.searchBox = new google.maps.places.Autocomplete(this.searchInput, options)
+			this.searchBox = new google.maps.places.Autocomplete(input, options)
 			this.searchBox.addListener('place_changed', this.onPlaceChanged)
+			enableEnterKey(input);
+			tagAutoCompleteContainer(input); 
 		}
 		let defaultZoom = 8,
 			defaultCenter = { lat: 0, lng: 180 }

--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -12,7 +12,7 @@ import { createClusters } from '../utils/clustering'
 import { objectsAreEqual } from '../utils/objects'
 import { strToFixed } from '../utils/string'
 import { parsePlace } from '../utils/parse-place'
-import { tagAutoCompleteContainer, enableEnterKey } from '../utils/suggestion-event'
+import { enableEnterKey } from '../utils/suggestion-event'
 
 export default class Map extends Component {
 	constructor(props) {
@@ -196,11 +196,10 @@ export default class Map extends Component {
 		if (this.props.initSearch) {
 			input.value = this.props.initSearch
 		}
-		if (this.searchInput) {
+		if (input) {
 			this.searchBox = new google.maps.places.Autocomplete(input, options)
 			this.searchBox.addListener('place_changed', this.onPlaceChanged)
-			enableEnterKey(input);
-			tagAutoCompleteContainer(input); 
+			enableEnterKey(input, this.searchBox)
 		}
 		let defaultZoom = 8,
 			defaultCenter = { lat: 0, lng: 180 }

--- a/src/containers/Search.js
+++ b/src/containers/Search.js
@@ -3,7 +3,7 @@ import { fitBounds } from 'google-map-react/utils';
 import { mapState } from '../state';
 
 import { parsePlace } from '../utils/parse-place'
-import { tagAutoCompleteContainer, enableEnterKey } from '../utils/suggestion-event'
+import { enableEnterKey } from '../utils/suggestion-event'
 
 function initSearch(google, options, getValue) {
   const input = document.querySelector('.storeLocatorSearchInput');
@@ -38,8 +38,7 @@ function initSearch(google, options, getValue) {
         }
       };
     });
-    enableEnterKey(input);
-    tagAutoCompleteContainer(input); 
+    enableEnterKey(input, searchBox)
   }
 }
 

--- a/src/containers/Search.js
+++ b/src/containers/Search.js
@@ -3,6 +3,7 @@ import { fitBounds } from 'google-map-react/utils';
 import { mapState } from '../state';
 
 import { parsePlace } from '../utils/parse-place'
+import { enableEnterKey } from '../utils/suggestion-event'
 
 function initSearch(google, options, getValue) {
   const input = document.querySelector('.storeLocatorSearchInput');
@@ -37,6 +38,7 @@ function initSearch(google, options, getValue) {
         }
       };
     });
+    enableEnterKey(input);
   }
 }
 

--- a/src/containers/Search.js
+++ b/src/containers/Search.js
@@ -3,7 +3,7 @@ import { fitBounds } from 'google-map-react/utils';
 import { mapState } from '../state';
 
 import { parsePlace } from '../utils/parse-place'
-import { enableEnterKey } from '../utils/suggestion-event'
+import { tagAutoCompleteContainer, enableEnterKey } from '../utils/suggestion-event'
 
 function initSearch(google, options, getValue) {
   const input = document.querySelector('.storeLocatorSearchInput');
@@ -39,6 +39,7 @@ function initSearch(google, options, getValue) {
       };
     });
     enableEnterKey(input);
+    tagAutoCompleteContainer(input); 
   }
 }
 

--- a/src/utils/suggestion-event.js
+++ b/src/utils/suggestion-event.js
@@ -1,0 +1,49 @@
+const enableEnterKey = (input) => {
+	const originalAddEventListener = input.addEventListener
+
+	const addEventListenerWrapper = (type, listener) => {
+		if (type === "keydown") {
+			const originalListener = listener;
+			listener = (event) =>
+			{
+				const pacContainerArray = document.getElementsByClassName('pac-container');
+				const suggestionsVisible = pacContainerArray.length > 0 ? pacContainerArray[0].style.display !== 'none' : false;
+				const suggestionSelected = document.getElementsByClassName('pac-item-selected').length > 0;
+ 
+				// enter key press
+				if (event.which === 13 || event.keyCode === 13) {
+					// user press enter while no suggestion is selected yet : auto-select first one(using fake arrow key) then it will be choosen by enter key press. preventDefault so form is not submitted
+					if (suggestionsVisible && !suggestionSelected) {
+						// make event from original event (copy)
+						const arrowDownEvent = JSON.parse(JSON.stringify(event, (k, v) => {
+							if (v instanceof Node) return 'Node';
+							if (v instanceof Window) return 'Window';
+							return v;
+						}, ' '));
+						arrowDownEvent.which = 40;
+						arrowDownEvent.keyCode = 40;
+ 
+						// send arrow down key press event (add simulated event) before return press)
+						originalListener.apply(input, [arrowDownEvent])
+ 
+						event.preventDefault();
+					} 
+ 
+					// suggestion is already selected (by arrow key) and user presses enter to choose it. preventDefault so form is not submitted
+					else if (suggestionsVisible && suggestionSelected) {
+						event.preventDefault();
+					}
+					// else if suggestions not visible do not prevent default (ex submit)
+				}
+ 
+				// sent (original) return key press event/
+				originalListener.apply(input, [event])
+			}
+		}
+		originalAddEventListener.apply(input, [type, listener])
+	}
+
+	input.addEventListener = addEventListenerWrapper;
+};
+
+export { enableEnterKey }

--- a/src/utils/suggestion-event.js
+++ b/src/utils/suggestion-event.js
@@ -4,39 +4,50 @@ const enableEnterKey = (input) => {
 	const addEventListenerWrapper = (type, listener) => {
 		if (type === "keydown") {
 			const originalListener = listener;
-			listener = (event) =>
-			{
-				const pacContainerArray = document.getElementsByClassName('pac-container');
-				const suggestionsVisible = pacContainerArray.length > 0 ? pacContainerArray[0].style.display !== 'none' : false;
-				const suggestionSelected = document.getElementsByClassName('pac-item-selected').length > 0;
+			listener = (event) => {
+				// 0. get autocomplete div corresponing to input field
+				const pacContainer = getAutoCompleteContainer(input);
+				if (pacContainer) {
+					// 1. check if it is visible (check if display property is not 'none')
+					const suggestionsVisible = pacContainer.style.display !== 'none';
  
-				// enter key press
-				if (event.which === 13 || event.keyCode === 13) {
-					// user press enter while no suggestion is selected yet : auto-select first one(using fake arrow key) then it will be choosen by enter key press. preventDefault so form is not submitted
-					if (suggestionsVisible && !suggestionSelected) {
-						// make event from original event (copy)
-						const arrowDownEvent = JSON.parse(JSON.stringify(event, (k, v) => {
-							if (v instanceof Node) return 'Node';
-							if (v instanceof Window) return 'Window';
-							return v;
-						}, ' '));
-						arrowDownEvent.which = 40;
-						arrowDownEvent.keyCode = 40;
+					// 2. check if one of the suggestions is selected
+					const suggestionSelected = pacContainer.getElementsByClassName('pac-item-selected').length > 0;
  
-						// send arrow down key press event (add simulated event) before return press)
-						originalListener.apply(input, [arrowDownEvent])
+					// return key press
+					if (event.which === 13 || event.keyCode === 13) {
+
+						// when user press enter while no suggestion is selected yet
+						if (suggestionsVisible && !suggestionSelected) {
+							// 3. make event from original event (copy)
+							const arrowDownEvent = JSON.parse(JSON.stringify(event, (k, v) =>
+							{
+								if (v instanceof Node) return 'Node';
+								if (v instanceof Window) return 'Window';
+								return v;
+							}, ' '));
+							// fake arrow down event to auto-select first suggestion (it will then be choosen by return down event)
+							arrowDownEvent.which = 40;
+							arrowDownEvent.keyCode = 40;
  
-						event.preventDefault();
-					} 
+							// 4. send arrow down key press event (add simulated event) before return press
+							originalListener.apply(input, [arrowDownEvent]);
  
-					// suggestion is already selected (by arrow key) and user presses enter to choose it. preventDefault so form is not submitted
-					else if (suggestionsVisible && suggestionSelected) {
-						event.preventDefault();
+							// 5. preventDefault so form is not submitted
+							event.preventDefault();
+						}
+
+						// when suggestion is already selected (by arrow key) and user presses return to choose it
+						else if (suggestionsVisible && suggestionSelected)
+						{
+							// 5. preventDefault so form is not submitted
+							event.preventDefault();
+						}
+						// if suggestions not visible do not prevent default (ex submit)
 					}
-					// else if suggestions not visible do not prevent default (ex submit)
 				}
  
-				// sent (original) return key press event/
+				// 6. send (original) return key press event
 				originalListener.apply(input, [event])
 			}
 		}
@@ -45,5 +56,37 @@ const enableEnterKey = (input) => {
 
 	input.addEventListener = addEventListenerWrapper;
 };
+ 
+const hasId = (element) => {
+	if (typeof element.id === 'string') {
+		return element.id.length > 0;
+	}
+	else return false;
+}
+ 
+const getAutoCompleteContainer = (input) => {
+	const autocompleteContainers = Array.prototype.filter.call(document.getElementsByClassName('pac-container'), (autocompleteContainer) => autocompleteContainer.id === input.id);
+ 
+	if (autocompleteContainers.length === 1) return autocompleteContainers[0];
+ 
+	else if (autocompleteContainers.length > 1) console.warn('found more than one corresponding google autcomplete container found')
+ 
+	else console.warn('could not find any corresponding google autocomplete container');
+}
 
-export { enableEnterKey }
+const tagAutoCompleteContainer = (input) => {
+	const id = (Math.random() + 1).toString(36).substring(7);
+	input.id = id;
+
+	// find google autocomplete input which is not tagged yet
+	const untaggedAutocompleteContainers = Array.prototype.filter.call(document.getElementsByClassName('pac-container'), (untaggedAutocompleteContainer) => !hasId(untaggedAutocompleteContainer));
+ 
+	// tag it (if found only one)
+	if (untaggedAutocompleteContainers.length === 1) untaggedAutocompleteContainers[0].id = id;
+ 
+	else if (untaggedAutocompleteContainers.length > 1) console.warn('found more than one untagged google autcomplete container')
+ 
+	else console.warn('could not find any untagged google autocomplete container');
+}
+
+export { enableEnterKey, tagAutoCompleteContainer }


### PR DESCRIPTION
This allows Google suggestion selection on return key press instead of having to click it (in AutoComplete, Search and Map search inputs).

First return key press selects the first suggestion, second key press triggers default event (such as submit if input is in a form).