### PR TITLE
remove customOptions prop to Autocomplete underlying input field

### DIFF
--- a/src/containers/AutoComplete.js
+++ b/src/containers/AutoComplete.js
@@ -69,6 +69,7 @@ class AutoComplete extends Component {
   delete updatedInput['google']
   delete updatedInput['googleApiKey']
   delete updatedInput['loaded']
+  delete updatedInput['customOptions']
 
   return (
    <input


### PR DESCRIPTION
This remove `customOptions` prop automatically passed to underlying input field in Autocomplete which can have side effects.