### PR TITLE
Realtime locations

### DIFF
--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -161,10 +161,9 @@ export default class Map extends Component {
 	}
 
 	createMapOptions() {
-		const { mapStyle } = this.props
-		const { styles } = this.props.mapOptions
+		const { mapStyle, mapOptions } = this.props
 		return {
-			styles: styles || mapStyle,
+			styles: mapOptions && mapOptions.styles || mapStyle,
 			...this.props.mapOptions
 		}
 	}

--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -11,10 +11,24 @@ import infoStyle from './InfoStyle'
 import searchStyle from './SearchStyle'
 import { createClusters } from '../utils/clustering'
 import { objectsAreEqual } from '../utils/objects'
+import { arraysAreEqual } from '../utils/arrays'
 import { strToFixed } from '../utils/string'
 import { addressFromPlace } from '../utils/parse-place'
 import { enableEnterKey } from '../utils/suggestion-event'
 import { mapState } from '../state'
+
+const getLocationsBounds = (locations) => {
+	const bounds = new google.maps.LatLngBounds()
+	locations.map(location => {
+		bounds.extend(
+			new google.maps.LatLng(
+				parseFloat(location.lat),
+				parseFloat(location.lng)
+			)
+		)
+	})
+	return bounds
+}
 
 export default class Map extends Component {
 	constructor(props) {
@@ -31,13 +45,14 @@ export default class Map extends Component {
 		this.searchByQuery = this.searchByQuery.bind(this)
 
 		this.state = {
-			updatedLocations: this.props.locations,
+			updatedLocations: props.locations, // locations + show state (toggled on/off)
+			bounds: getLocationsBounds(props.locations), // depends on how the inital location is set
 			center: { lat: 0, lng: 0 },
 			zoom: 6,
 			place: null,
 			mapLoaded: false,
 			props: null,
-			newBounds: null,
+			newBounds: null, // does not seem to change
 			searchInput: ``
 		}
 	}
@@ -59,6 +74,31 @@ export default class Map extends Component {
 				}}
 				`
 			)
+		}
+	}
+
+	// state locations (including show state) within map bounds
+	updatedLocationsInBounds({ne, sw})
+	{
+		const { updatedLocations } = this.state;
+
+		if (ne && sw) {
+			return updatedLocations.filter(location => {
+				const lat = strToFixed(location.lat, 6)
+				const lng = strToFixed(location.lng, 6)
+				if (
+					lat >= strToFixed(sw.lat, 6) &&
+					lat <= strToFixed(ne.lat, 6) &&
+					lng >= strToFixed(sw.lng, 6) &&
+					lng <= strToFixed(ne.lng, 6)
+				) {
+					return location
+				}
+			})
+		}
+		else {
+			console.error(`invalid bounds : (${JSON.stringify(ne)},${JSON.stringify(sw)})`)
+			return updatedLocations;
 		}
 	}
 
@@ -90,40 +130,33 @@ export default class Map extends Component {
 					? props.bounds.sw.lng - 360
 					: props.bounds.sw.lng
 		}
-		const { ne, sw } = bounds
-		const { locations } = this.props
-		// locations within the map bounds
 
-		const foundLocations = locations.filter(location => {
-			const lat = strToFixed(location.lat, 6)
-			const lng = strToFixed(location.lng, 6)
-			if (
-				lat >= strToFixed(sw.lat, 6) &&
-				lat <= strToFixed(ne.lat, 6) &&
-				lng >= strToFixed(sw.lng, 6) &&
-				lng <= strToFixed(ne.lng, 6)
-			) {
-				return location
-			}
-		})
+		// locations within the map bounds
+		const updatedLocationsInBounds = this.updatedLocationsInBounds(bounds);
+
 		// if enableClusters is enabled create clusters and set them to the state
 		if (this.props.enableClusters) {
 			const { cluster } = this.props
+			const { updatedLocations } = this.state
 			this.setState({
 				updatedLocations: createClusters(
 					props,
-					foundLocations.length > 0 ? foundLocations : locations,
+					updatedLocationsInBounds.length > 0 ? updatedLocationsInBounds : updatedLocations,
 					cluster && cluster.radius,
 					cluster && cluster.extent,
 					cluster && cluster.nodeSize,
 					cluster && cluster.minZoom,
 					cluster && cluster.maxZoom
-				)
+				),
+				bounds
 			})
+		}
+		else {
+			this.setState({ bounds })
 		}
 
 		// find the distance from the center for each location
-		foundLocations.map(location => {
+		const updatedLocationsInBoundsWithDistance = updatedLocationsInBounds.map(location => {
 			const distanceMeters = geolib.getDistance(center, {
 				lat: location.lat,
 				lng: location.lng
@@ -133,31 +166,26 @@ export default class Map extends Component {
 			return { ...location }
 		})
 
-		if (!this.props.enableClusters) {
-			this.setState({ updatedLocations: foundLocations })
-		}
 
-		if (this.props.onChange) {
-			if (foundLocations) {
-				this.props.onChange(foundLocations)
-			}
+		if (this.props.onChange && updatedLocationsInBoundsWithDistance) {
+			this.props.onChange(updatedLocationsInBoundsWithDistance)
 		}
 	}
 
 	toggleLocation(id) {
-		const locations = this.state.updatedLocations.map(location => ({
+		const updatedLocations = this.state.updatedLocations.map(location => ({
 			...location,
 			show: location.id === id ? !location.show : false
 		}))
-		this.setState({ updatedLocations: locations })
+		this.setState({ updatedLocations })
 	}
 
 	closeLocation(id) {
-		const locations = this.state.updatedLocations.map(location => ({
+		const updatedLocations = this.state.updatedLocations.map(location => ({
 			...location,
 			show: false
 		}))
-		this.setState({ updatedLocations: locations })
+		this.setState({ updatedLocations })
 	}
 
 	createMapOptions() {
@@ -231,49 +259,35 @@ export default class Map extends Component {
 
 	getLocationsViewport() {
 		let center, zoom
+		const { locations, defaultCenter, defaultZoom } = this.props
 
-		if (this.props.locations.length === 1) {
+		if (locations.length === 1) {
 			center = {
-				lat: parseFloat(this.props.locations[0].lat),
-				lng: parseFloat(this.props.locations[0].lng)
+				lat: parseFloat(locations[0].lat),
+				lng: parseFloat(locations[0].lng)
 			}
 		} else {
-			const bounds = new google.maps.LatLngBounds()
-			this.props.locations.map(location => {
-				bounds.extend(
-					new google.maps.LatLng(
-						parseFloat(location.lat),
-						parseFloat(location.lng)
-					)
-				)
-			})
+			const bounds = getLocationsBounds(locations)
 			const viewport = this.viewPortWithBounds(bounds)
 			center = viewport.center
 			zoom = viewport.zoom
 		}
 
 		return {
-			center: center || this.props.defaultCenter,
-			zoom: zoom || this.props.defaultZoom
+			center: center || defaultCenter,
+			zoom: zoom || defaultZoom
 		}
 	}
 
 	getCurrentArea() {
-		const bounds = new google.maps.LatLngBounds()
-		this.props.locations.map(location => {
-			bounds.extend(
-				new google.maps.LatLng(
-					parseFloat(location.lat),
-					parseFloat(location.lng)
-				)
-			)
-		})
+		const { locations } = this.props
+		const bounds = getLocationsBounds(locations)
 
 		let center
-		if (this.props.locations.length === 1) {
+		if (locations.length === 1) {
 			center = {
-				lat: parseFloat(this.props.locations[0].lat),
-				lng: parseFloat(this.props.locations[0].lng)
+				lat: parseFloat(locations[0].lat),
+				lng: parseFloat(locations[0].lng)
 			}
 		} else {
 			center = {
@@ -368,20 +382,44 @@ export default class Map extends Component {
 		}
 		this.setState({
 			zoom: initialZoom || this.props.defaultZoom,
-			center: initialCenter || this.props.defaultCenter
+			center: initialCenter || this.props.defaultCenter,
+			// bounds
 		})
 	}
 
 	componentDidUpdate(prevProps, prevState) {
-		const { initSearch, place } = this.props
-		if (place && prevProps.place !== place && place !== this.state.place) {
-			this.moveMap(place)
+		const { initSearch: propsInitSearch, place: propsPlace, locations: propsLocations } = this.props
+		const { initSearch: prevPropsInitSearch, place: prevPropsPlace, locations: prevPropsLocations } = prevProps
+		const { place: statePlace, updatedLocations: stateUpdatedLocations } = this.state
+		const { place: prevStatePlace, updatedLocations: prevStateUpdatedLocations } = prevState
+
+		// add or remove any new or deleted location
+		if (propsLocations)
+		{
+			const prevPropsLocationsArray = prevPropsLocations ? prevPropsLocations : [];
+			const prevPropsLocationsIds = prevPropsLocationsArray.map(location => location.id);
+			const propsLocationsIds = propsLocations.map(location => location.id);
+			if (!arraysAreEqual(prevPropsLocationsIds, propsLocationsIds))
+			{
+				// get added locations (in propsLocations and not in prevPropsLocations)
+				const addedLocations = propsLocations.filter(propsLocation => !prevPropsLocationsIds.includes(propsLocation.id));
+				// get removed locations (in prevPropsLocations and not in propsLocations)
+				const removedLocations = prevPropsLocationsArray.filter(prevPropsLocation => !propsLocationsIds.includes(prevPropsLocation.id));
+				// update state immutably (merge & filter) - keep show state of existing locations
+				const updatedLocations = [...stateUpdatedLocations, ...addedLocations].filter(location => !removedLocations.map(loc => loc.id).includes(location.id))
+				this.setState({ updatedLocations });
+			}
 		}
-		if (this.state.place && this.state.place !== prevState.place) {
-			this.moveMap(this.state.place)
+	
+
+		if (propsPlace && prevPropsPlace !== propsPlace && propsPlace !== statePlace) {
+			this.moveMap(propsPlace)
 		}
-		if (initSearch && prevProps.initSearch !== initSearch) {
-			this.searchByQuery(initSearch)
+		if (statePlace && statePlace !== prevStatePlace) {
+			this.moveMap(statePlace)
+		}
+		if (propsInitSearch && prevPropsInitSearch !== propsInitSearch) {
+			this.searchByQuery(propsInitSearch)
 		}
 	}
 
@@ -464,7 +502,10 @@ export default class Map extends Component {
 			? this.props.clusterPin.component
 			: this.props.defaultClusterPin
 
-		const { updatedLocations, zoom, center } = this.state
+		const { bounds, zoom, center } = this.state
+
+		const updatedLocationsInBounds = this.updatedLocationsInBounds(bounds);
+
 		return (
 			<div
 				style={{
@@ -507,7 +548,7 @@ export default class Map extends Component {
 					onChange={this.onMapChanged}
 					gestureHandling={this.props.gestureHandling || `cooperative`}
 				>
-					{updatedLocations.map(location => {
+					{updatedLocationsInBounds.map(location => {
 						if (location.cluster_id) {
 							return (
 								<ClusterPin

--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -46,7 +46,6 @@ export default class Map extends Component {
 
 		this.state = {
 			updatedLocations: props.locations, // locations + show state (toggled on/off)
-			bounds: getLocationsBounds(props.locations), // depends on how the inital location is set
 			center: { lat: 0, lng: 0 },
 			zoom: 6,
 			place: null,
@@ -147,12 +146,8 @@ export default class Map extends Component {
 					cluster && cluster.nodeSize,
 					cluster && cluster.minZoom,
 					cluster && cluster.maxZoom
-				),
-				bounds
+				)
 			})
-		}
-		else {
-			this.setState({ bounds })
 		}
 
 		// find the distance from the center for each location
@@ -382,8 +377,7 @@ export default class Map extends Component {
 		}
 		this.setState({
 			zoom: initialZoom || this.props.defaultZoom,
-			center: initialCenter || this.props.defaultCenter,
-			// bounds
+			center: initialCenter || this.props.defaultCenter
 		})
 	}
 
@@ -502,9 +496,9 @@ export default class Map extends Component {
 			? this.props.clusterPin.component
 			: this.props.defaultClusterPin
 
-		const { bounds, zoom, center } = this.state
+		const { zoom, center, updatedLocations } = this.state
 
-		const updatedLocationsInBounds = this.updatedLocationsInBounds(bounds);
+		const updatedLocationsInBounds = this.map ? this.updatedLocationsInBounds(this.map.getBounds) : updatedLocations;
 
 		return (
 			<div

--- a/src/utils/arrays.js
+++ b/src/utils/arrays.js
@@ -1,0 +1,13 @@
+const arraysAreEqual = (array1, array2) => {
+	let areEqual = true
+
+	if (array1.length != array2.length) areEqual = false; 
+	else {
+		const array2IncludesArray1 = array1.every(element => array2.includes(element)); 
+		const array1IncludesArray2 = array2.every(element => array1.includes(element)); 
+		areEqual = array1IncludesArray2 && array2IncludesArray1; 
+	}
+	return areEqual
+}
+
+export { arraysAreEqual }


### PR DESCRIPTION
allows map pins to appear instantly on map on `locations` change. killer feature when using a reactive source for react-store-locator.

You might want to check line [163](https://github.com/escaladesports/react-store-locator/blob/ed72adc9ef3f9e3ac7011144b745029279e9519e/src/containers/Map.js#L163) as I am not sure which locations to use for clustering (this is not a feature I personally use), that is should it be all locations or only the ones within map bounds ?

depends on #43 